### PR TITLE
add headline4 to headlineMedium

### DIFF
--- a/lib/static/files_json.dart
+++ b/lib/static/files_json.dart
@@ -318,7 +318,7 @@ class HomeView extends StatelessWidget {
                 final counter = ref.watch(homeControllerProvider);
                 return Text(
                   'Counter: \$counter',
-                  style: Theme.of(context).textTheme.headline4,
+                  style: Theme.of(context).textTheme.headlineMedium,
                 );
               },
             ),


### PR DESCRIPTION
When creating a new page, I encountered an error:

The getter 'headline4' isn't defined for the type 'TextTheme'.

This happened because Flutter’s text theme API has been updated. I resolved the issue by replacing headline4 with headlineMedium in the code:

Theme.of(context).textTheme.headlineMedium

Now everything works fine.